### PR TITLE
NAND gate fix.

### DIFF
--- a/AlteraLab3/part2.v
+++ b/AlteraLab3/part2.v
@@ -20,8 +20,8 @@ module flippyfloppy (Clk, D, Q);
 
   wire R_g, S_g, Qa, Qb /* synthesis keep */ ;
 
-  assign R_g = R & Clk;
-  assign S_g = S & Clk;
+  assign R_g = ~(R & Clk);
+  assign S_g = ~(S & Clk);
   assign Qa = ~(R_g | Qb);
   assign Qb = ~(S_g | Qa);
 


### PR DESCRIPTION
Looking at the circuit diagram of D Latch in the lab3_Verilog.pdf, wire R_g and S_g should be as I've fixed, if I am not mistaken.